### PR TITLE
Build system compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,9 @@ project(pico-ros VERSION ${version})
 
 option(PICOROS_BUILD_EXAMPLES "Build examples" ON)
 option(PICOROS_BUILD_TESTS "Build tests" ON)
-message("PICOROS_BUILD_EXAMPLES: ${PICOROS_BUILD_EXAMPLES}")
+message("-- PICOROS_BUILD_EXAMPLES: ${PICOROS_BUILD_EXAMPLES}")
+message("-- PICOROS_BUILD_TESTS: ${PICOROS_BUILD_TESTS}")
+message("-- PICOROS USER_TYPE_FILE: ${USER_TYPE_FILE}")
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 11)
@@ -20,7 +22,6 @@ if(CMAKE_EXPORT_COMPILE_COMMANDS)
       ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 endif()
 
-
 # zenoh-pico
 set(BUILD_EXAMPLES OFF)
 set(BUILD_SHARED_LIBS OFF)
@@ -28,61 +29,62 @@ add_subdirectory(thirdparty/zenoh-pico)
 
 # Micro-CDR
 add_library(microcdr STATIC
-    thirdparty/Micro-CDR/src/c/common.c
-    thirdparty/Micro-CDR/src/c/common_internal.h
-    thirdparty/Micro-CDR/src/c/types/array.c
-    thirdparty/Micro-CDR/src/c/types/basic.c
-    thirdparty/Micro-CDR/src/c/types/sequence.c
-    thirdparty/Micro-CDR/src/c/types/string.c
+  thirdparty/Micro-CDR/src/c/common.c
+  thirdparty/Micro-CDR/src/c/common_internal.h
+  thirdparty/Micro-CDR/src/c/types/array.c
+  thirdparty/Micro-CDR/src/c/types/basic.c
+  thirdparty/Micro-CDR/src/c/types/sequence.c
+  thirdparty/Micro-CDR/src/c/types/string.c
 )
 target_include_directories(microcdr PUBLIC
-    thirdparty/Micro-CDR/include
-    thirdparty/config
+  thirdparty/Micro-CDR/include
+  thirdparty/config
 )
 
+# picoros
 add_library(picoros STATIC
-    src/picoros.c
-    src/picoros.h
+  src/picoros.c
+  src/picoros.h
 )
 target_include_directories(picoros PUBLIC
-     src/
+  src/
 )
+target_link_libraries(picoros zenohpico::lib)
 
+# picoserdes
 add_library(picoserdes STATIC
-    src/picoserdes.c
-    src/picoserdes.h
+  src/picoserdes.c
+  src/picoserdes.h
 )
 target_include_directories(picoserdes PUBLIC
-     src/
+  src/
 )
+if(USER_TYPE_FILE)
+  target_compile_definitions(picoserdes PUBLIC -DUSER_TYPE_FILE="${USER_TYPE_FILE}")
+endif()
+target_link_libraries(picoserdes microcdr)
 
+# picoparams
 add_library(picoparams STATIC
-    src/picoparams.c
-    src/picoparams.h
+  src/picoparams.c
+  src/picoparams.h
 )
 target_include_directories(picoparams PUBLIC
-     src/
+  src/
 )
-
-if (TYPE_FILE)
-  message("USER_TYPE_FILE: ${TYPE_FILE}")
-  target_compile_definitions(picoserdes PUBLIC -DUSER_TYPE_FILE="${TYPE_FILE}")
-endif()
-
-target_link_libraries(picoros zenohpico::lib)
-target_link_libraries(picoserdes microcdr)
 target_link_libraries(picoparams zenohpico::lib microcdr picors picoserdes)
+
   
-  # Add test executable
-if(PICOROS_BUILD_TESTS AND TYPE_FILE)
-  message("User types serdes tests enabled")
+# Add test executable
+if(PICOROS_BUILD_TESTS AND USER_TYPE_FILE)
+  message("-- PICOROS User types serdes tests enabled.")
   add_executable(test_user_types_serdes test/test_picoserdes.c)
   target_include_directories(test_user_types_serdes PRIVATE src)
   target_link_libraries(test_user_types_serdes PRIVATE picoserdes microcdr)
   add_test(NAME test_user_types_serdes COMMAND test_user_types)
 endif()
   
-  # Build examples if enabled
+# Build examples if enabled
 if(PICOROS_BUILD_EXAMPLES)
   add_library(examples_serdes STATIC
     src/picoserdes.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,18 @@ set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(thirdparty/zenoh-pico)
 
 # Micro-CDR
-set(UCDR_SUPERBUILD OFF)
-set(UCDR_ISOLATED_INSTALL OFF)
-add_subdirectory(thirdparty/Micro-CDR)
+add_library(microcdr STATIC
+    thirdparty/Micro-CDR/src/c/common.c
+    thirdparty/Micro-CDR/src/c/common_internal.h
+    thirdparty/Micro-CDR/src/c/types/array.c
+    thirdparty/Micro-CDR/src/c/types/basic.c
+    thirdparty/Micro-CDR/src/c/types/sequence.c
+    thirdparty/Micro-CDR/src/c/types/string.c
+)
+target_include_directories(microcdr PUBLIC
+    thirdparty/Micro-CDR/include
+    thirdparty/config
+)
 
 add_library(picoros STATIC
     src/picoros.c

--- a/readme.md
+++ b/readme.md
@@ -46,8 +46,9 @@
    ```
 
 #### Build Options
-- Custom type definitions: `-DUSER_TYPE_FILE="user_types.h"`
+- Custom type definitions: `-DUSER_TYPE_FILE=user_types.h`
 - Disable examples: `-DPICOROS_BUILD_EXAMPLES=OFF`
+- Disable tests: `-DPICOROS_BUILD_TESTS=OFF`
 
 ### Examples
 

--- a/thirdparty/config/ucdr/config.h
+++ b/thirdparty/config/ucdr/config.h
@@ -1,0 +1,27 @@
+// Copyright 2017 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef _MICROCDR_CONFIG_H_
+#define _MICROCDR_CONFIG_H_
+
+// Version defines
+//#define MICROCDR_VERSION_MAJOR @PROJECT_VERSION_MAJOR@
+//#define MICROCDR_VERSION_MINOR @PROJECT_VERSION_MINOR@
+//#define MICROCDR_VERSION_MICRO @PROJECT_VERSION_PATCH@
+//#define MICROCDR_VERSION_STR "@PROJECT_VERSION@"
+
+// ucdrEndianness defines
+#define UCDR_MACHINE_ENDIANNESS UCDR_LITTLE_ENDIANNESS
+
+#endif // _MICROCDR_CONFIG_H_


### PR DESCRIPTION
Add manual build of Micro-CDR and include ucdr/config.h in this repository.

Potentially make it easier to integrate with various build systems and toolchains.