### PR TITLE
Resource cleanup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "thirdparty/zenoh-pico"]
 	path = thirdparty/zenoh-pico
-	url = https://github.com/eclipse-zenoh/zenoh-pico
+	url = git@github.com:g4sp3r/zenoh-pico.git
 [submodule "thirdparty/Micro-CDR"]
 	path = thirdparty/Micro-CDR
 	url = https://github.com/eProsima/Micro-CDR

--- a/examples/batteryState_publisher.c
+++ b/examples/batteryState_publisher.c
@@ -96,6 +96,7 @@ int main(int argc, char **argv){
 
     printf("Closing interface and cleaning up...\n");
     picoros_publisher_drop(&pub_bs);
+    picoros_node_drop(&node);
     picoros_interface_close();
 
     return 0;

--- a/examples/batteryState_publisher.c
+++ b/examples/batteryState_publisher.c
@@ -2,16 +2,17 @@
  * @file    batteryState_publisher.c
  * @brief   Example batteryState publisher node for picoros
  * @date    2025-Aug-20
- * 
+ *
  * @details This example demonstrates a ROS publisher node that publishes
  *          simulated batteryState messages on the "battery_state" topic.
- * 
+ *
  * @copyright Copyright (c) 2025 Ubiquity Robotics
  *******************************************************************************/
-  
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <signal.h>
 #include "picoros.h"
 #include "picoserdes.h"
 
@@ -20,7 +21,9 @@
 #define LOCATOR     "tcp/192.168.1.16:7447"
 
 // Common utils
-extern int picoros_parse_args(int argc, char **argv, picoros_interface_t* ifx);
+extern int sys_parse_args(int argc, char **argv, picoros_interface_t* ifx);
+extern volatile sig_atomic_t picoros_keep_running;
+extern void sys_setup_sigint_handler(void);
 
 // Example Publisher
 picoros_publisher_t pub_bs = {
@@ -68,8 +71,7 @@ int main(int argc, char **argv){
         .mode = MODE,
         .locator = LOCATOR,
     };
-    int ret = picoros_parse_args(argc, argv , &ifx);
-
+    int ret = sys_parse_args(argc, argv , &ifx);
     if(ret != 0){
         return ret;
     }
@@ -86,9 +88,15 @@ int main(int argc, char **argv){
     printf("Declaring publisher on %s\n", pub_bs.topic.name);
     picoros_publisher_declare(&node, &pub_bs);
 
-    while(true){
+    sys_setup_sigint_handler();
+    while(picoros_keep_running){
         publish_batteyState();
         z_sleep_s(1);
     }
+
+    printf("Closing interface and cleaning up...\n");
+    picoros_publisher_drop(&pub_bs);
+    picoros_interface_close();
+
     return 0;
 }

--- a/examples/common.c
+++ b/examples/common.c
@@ -2,18 +2,35 @@
  * @file    common.c
  * @brief   Common utilities for picoros examples
  * @date    2025-May-27
- * 
+ *
  * @details This file provides common utility functions used across
  *          the example programs,
- * 
+ *
  * @copyright Copyright (c) 2025 Ubiquity Robotics
  *******************************************************************************/
 
 #include "picoros.h"
 #include <stdio.h>
 #include <unistd.h>
+#include <signal.h>
 
-int picoros_parse_args(int argc, char **argv, picoros_interface_t* ifx) {
+volatile sig_atomic_t picoros_keep_running = 1;
+
+void handle_sigint(int sig) {
+    (void)sig;
+    printf("\nGot SIGINT.\n");
+    if (picoros_keep_running == 0){
+        printf("Forcing stop.\n");
+        exit(-1);
+    }
+    picoros_keep_running = 0;
+}
+
+void sys_setup_sigint_handler(void) {
+    signal(SIGINT, handle_sigint);
+}
+
+int sys_parse_args(int argc, char **argv, picoros_interface_t* ifx) {
     int opt;
     while ((opt = getopt(argc, argv, "a:m:h")) != -1) {
         switch (opt) {

--- a/examples/jointState_publisher.cpp
+++ b/examples/jointState_publisher.cpp
@@ -11,6 +11,7 @@
 
 #include <cstdio>
 #include <cstdint>
+#include <csignal>
 #include "picoros.h"
 #include "picoserdes.h"
 #include "zenoh-pico/system/common/platform.h"
@@ -21,7 +22,9 @@ constexpr const char* MODE = "client";
 constexpr const char* LOCATOR = "tcp/192.168.1.16:7447";
 
 // Common utils
-extern "C" int picoros_parse_args(int argc, char **argv, picoros_interface_t* ifx);
+extern "C" int sys_parse_args(int argc, char **argv, picoros_interface_t* ifx);
+extern "C" volatile sig_atomic_t picoros_keep_running;
+extern "C" void sys_setup_sigint_handler(void);
 
 // Example Publisher
 picoros_publisher_t publisher = {
@@ -74,11 +77,11 @@ int main(int argc, char **argv) {
         .mode = const_cast<char*>(MODE),
         .locator = const_cast<char*>(LOCATOR),
     };
-    int ret = picoros_parse_args(argc, argv, &ifx);
-
+    int ret = sys_parse_args(argc, argv, &ifx);
     if (ret != 0) {
         return ret;
     }
+
 
     std::printf("Starting pico-ros interface %s %s\n", ifx.mode, ifx.locator);
     while (picoros_interface_init(&ifx) == PICOROS_NOT_READY) {
@@ -92,9 +95,15 @@ int main(int argc, char **argv) {
     std::printf("Declaring publisher on %s\n", publisher.topic.name);
     picoros_publisher_declare(&node, &publisher);
 
-    while (true) {
+    sys_setup_sigint_handler();
+    while (picoros_keep_running) {
         publish_jointState();
         z_sleep_s(1);
     }
+
+    std::printf("Closing interface and cleaning up...\n");
+    picoros_publisher_drop(&publisher);
+    picoros_interface_close();
+
     return 0;
 }

--- a/examples/jointState_publisher.cpp
+++ b/examples/jointState_publisher.cpp
@@ -103,6 +103,7 @@ int main(int argc, char **argv) {
 
     std::printf("Closing interface and cleaning up...\n");
     picoros_publisher_drop(&publisher);
+    picoros_node_drop(&node);
     picoros_interface_close();
 
     return 0;

--- a/examples/listener.c
+++ b/examples/listener.c
@@ -2,15 +2,16 @@
  * @file    listener.c
  * @brief   Example listener node for picoros
  * @date    2025-May-27
- * 
+ *
  * @details This example demonstrates a simple ROS subscriber node that
  *          listens to string messages on the "picoros/chatter" topic.
- * 
+ *
  * @copyright Copyright (c) 2025 Ubiquity Robotics
  *******************************************************************************/
 
 #include <stdio.h>
 #include <stdint.h>
+#include <signal.h>
 #include "picoros.h"
 #include "picoserdes.h"
 
@@ -19,7 +20,9 @@
 #define LOCATOR     "tcp/192.168.1.16:7447"
 
 // Common utils
-extern int picoros_parse_args(int argc, char **argv, picoros_interface_t* ifx);
+extern int sys_parse_args(int argc, char **argv, picoros_interface_t* ifx);
+extern volatile sig_atomic_t picoros_keep_running;
+extern void sys_setup_sigint_handler(void);
 
 // Subscriber callback
 void log_callback(uint8_t*, size_t);
@@ -50,8 +53,7 @@ int main(int argc, char **argv){
         .mode = MODE,
         .locator = LOCATOR,
     };
-    int ret = picoros_parse_args(argc, argv , &ifx);
-
+    int ret = sys_parse_args(argc, argv , &ifx);
     if(ret != 0){
         return ret;
     }
@@ -67,8 +69,14 @@ int main(int argc, char **argv){
     printf("Declaring subscriber on %s\n", sub_log.topic.name);
     picoros_subscriber_declare(&node, &sub_log);
 
-    while(true){
+    sys_setup_sigint_handler();
+    while(picoros_keep_running){
         z_sleep_s(1);
     }
+
+    printf("Closing interface and cleaning up...\n");
+    picoros_subscriber_drop(&sub_log);
+    picoros_interface_close();
+
     return 0;
 }

--- a/examples/listener.c
+++ b/examples/listener.c
@@ -76,6 +76,7 @@ int main(int argc, char **argv){
 
     printf("Closing interface and cleaning up...\n");
     picoros_subscriber_drop(&sub_log);
+    picoros_node_drop(&node);
     picoros_interface_close();
 
     return 0;

--- a/examples/odometry_listener.c
+++ b/examples/odometry_listener.c
@@ -11,6 +11,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <signal.h>
 #include "picoros.h"
 #include "picoserdes.h"
 
@@ -19,7 +20,9 @@
 #define LOCATOR     "tcp/192.168.1.16:7447"
 
 // Common utils
-extern int picoros_parse_args(int argc, char **argv, picoros_interface_t* ifx);
+extern int sys_parse_args(int argc, char **argv, picoros_interface_t* ifx);
+extern volatile sig_atomic_t picoros_keep_running;
+extern void sys_setup_sigint_handler(void);
 
 // Subscriber callback
 void odometry_callback(uint8_t* rx_data, size_t data_len);
@@ -57,8 +60,7 @@ int main(int argc, char **argv){
         .mode = MODE,
         .locator = LOCATOR,
     };
-    int ret = picoros_parse_args(argc, argv , &ifx);
-
+    int ret = sys_parse_args(argc, argv , &ifx);
     if(ret != 0){
         return ret;
     }
@@ -74,8 +76,14 @@ int main(int argc, char **argv){
     printf("Declaring subscriber on %s\n", sub_odo.topic.name);
     picoros_subscriber_declare(&node, &sub_odo);
 
-    while(true){
+    sys_setup_sigint_handler();
+    while(picoros_keep_running){
         z_sleep_s(1);
     }
+
+    printf("Closing interface and cleaning up...\n");
+    picoros_subscriber_drop(&sub_odo);
+    picoros_interface_close();
+
     return 0;
 }

--- a/examples/odometry_listener.c
+++ b/examples/odometry_listener.c
@@ -83,6 +83,7 @@ int main(int argc, char **argv){
 
     printf("Closing interface and cleaning up...\n");
     picoros_subscriber_drop(&sub_odo);
+    picoros_node_drop(&node);
     picoros_interface_close();
 
     return 0;

--- a/examples/odometry_publisher.c
+++ b/examples/odometry_publisher.c
@@ -11,6 +11,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <signal.h>
 #include "picoros.h"
 #include "picoserdes.h"
 
@@ -19,7 +20,9 @@
 #define LOCATOR     "tcp/192.168.1.16:7447"
 
 // Common utils
-extern int picoros_parse_args(int argc, char **argv, picoros_interface_t* ifx);
+extern int sys_parse_args(int argc, char **argv, picoros_interface_t* ifx);
+extern volatile sig_atomic_t picoros_keep_running;
+extern void sys_setup_sigint_handler(void);
 
 // Example Publisher
 picoros_publisher_t pub_odo = {
@@ -63,8 +66,7 @@ int main(int argc, char **argv){
         .mode = MODE,
         .locator = LOCATOR,
     };
-    int ret = picoros_parse_args(argc, argv , &ifx);
-
+    int ret = sys_parse_args(argc, argv , &ifx);
     if(ret != 0){
         return ret;
     }
@@ -81,9 +83,15 @@ int main(int argc, char **argv){
     printf("Declaring publisher on %s\n", pub_odo.topic.name);
     picoros_publisher_declare(&node, &pub_odo);
 
-    while(true){
+    sys_setup_sigint_handler();
+    while(picoros_keep_running){
         publish_odometry();
         z_sleep_s(1);
     }
+
+    printf("Closing interface and cleaning up...\n");
+    picoros_publisher_drop(&pub_odo);
+    picoros_interface_close();
+
     return 0;
 }

--- a/examples/odometry_publisher.c
+++ b/examples/odometry_publisher.c
@@ -91,6 +91,7 @@ int main(int argc, char **argv){
 
     printf("Closing interface and cleaning up...\n");
     picoros_publisher_drop(&pub_odo);
+    picoros_node_drop(&node);
     picoros_interface_close();
 
     return 0;

--- a/examples/params_server.c
+++ b/examples/params_server.c
@@ -2,16 +2,17 @@
  * @file    params_server.c
  * @brief   Example parameter server node for picoros
  * @date    2025-May-27
- * 
+ *
  * @details This example demonstrates a ROS parameter server implementation
  *          that handles needed requests to support configuration with rqt_reconfigure.
- * 
+ *
  * @copyright Copyright (c) 2025 Ubiquity Robotics
  *******************************************************************************/
 
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
+#include <signal.h>
 #include "picoros.h"
 #include "picoparams.h"
 
@@ -20,7 +21,9 @@
 #define LOCATOR     "tcp/192.168.1.16:7447"
 
 // Common utils
-extern int picoros_parse_args(int argc, char **argv,  picoros_interface_t* ifx);
+extern int sys_parse_args(int argc, char **argv,  picoros_interface_t* ifx);
+extern volatile sig_atomic_t picoros_keep_running;
+extern void sys_setup_sigint_handler(void);
 
 // Static buffer for service reply serialization, used from zenoh threads
 #define STATIC_BUF_SIZE 4096
@@ -90,7 +93,7 @@ int main(int argc, char **argv){
         .mode = MODE,
         .locator = LOCATOR,
     };
-    int ret = picoros_parse_args(argc, argv , &ifx);
+    int ret = sys_parse_args(argc, argv , &ifx);
     if(ret != 0){
         return ret;
     }
@@ -104,8 +107,8 @@ int main(int argc, char **argv){
     picoros_node_init(&node);
 
     picoparams_interface_t params_ifx = {
-            .f_ref = api_param_ref,
-            .f_get = api_param_get,
+        .f_ref = api_param_ref,
+        .f_get = api_param_get,
             .f_set = api_param_set,
             .f_describe = api_param_describe,
             .f_type = api_param_type,
@@ -120,9 +123,15 @@ int main(int argc, char **argv){
     }
     printf("Parameter server started\n");
 
-    while(true){
+    sys_setup_sigint_handler();
+    while(picoros_keep_running){
         z_sleep_s(1);
     }
+
+    printf("Closing interface and cleaning up...\n");
+    picoparams_stop();
+    picoros_interface_close();
+
     return 0;
 }
 

--- a/examples/srv_client_add2ints.c
+++ b/examples/srv_client_add2ints.c
@@ -11,6 +11,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <signal.h>
 #include "picoros.h"
 #include "picoserdes.h"
 
@@ -19,7 +20,9 @@
 #define LOCATOR     "tcp/192.168.1.16:7447"
 
 // Common utils
-extern int picoros_parse_args(int argc, char **argv,  picoros_interface_t* ifx);
+extern int sys_parse_args(int argc, char **argv,  picoros_interface_t* ifx);
+extern volatile sig_atomic_t picoros_keep_running;
+extern void sys_setup_sigint_handler(void);
 
 // Service reply callback
 void add2_client_cb(picoros_srv_client_t* client, uint8_t* reply_data, size_t reply_size,  bool error);
@@ -56,7 +59,7 @@ int main(int argc, char **argv){
         .mode = MODE,
         .locator = LOCATOR,
     };
-    int ret = picoros_parse_args(argc, argv , &ifx);
+    int ret = sys_parse_args(argc, argv , &ifx);
     if(ret != 0){
         return ret;
     }
@@ -69,9 +72,10 @@ int main(int argc, char **argv){
 
     picoros_service_client_init(&add2_client);
 
+    sys_setup_sigint_handler();
     int a = 0;
     int b = 100;
-    while(true){
+    while(picoros_keep_running){
         uint8_t buf[100];
         request_srv_AddTwoInts request = {.a=a, b=b};
         size_t len = ps_serialize(buf, &request, 100);
@@ -81,5 +85,10 @@ int main(int argc, char **argv){
         }
         z_sleep_ms(100);
     }
+
+    printf("Closing interface and cleaning up...\n");
+    picoros_service_client_drop(&add2_client);
+    picoros_interface_close();
+
     return 0;
 }

--- a/examples/srv_server_add2ints.c
+++ b/examples/srv_server_add2ints.c
@@ -94,6 +94,7 @@ int main(int argc, char **argv){
 
     printf("Closing interface and cleaning up...\n");
     picoros_service_drop(&add2_srv);
+    picoros_node_drop(&node);
     picoros_interface_close();
 
     return 0;

--- a/examples/srv_server_add2ints.c
+++ b/examples/srv_server_add2ints.c
@@ -11,6 +11,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <signal.h>
 #include "picoros.h"
 #include "picoserdes.h"
 
@@ -19,7 +20,9 @@
 #define LOCATOR     "tcp/192.168.1.16:7447"
 
 // Common utils
-extern int picoros_parse_args(int argc, char **argv,  picoros_interface_t* ifx);
+extern int sys_parse_args(int argc, char **argv,  picoros_interface_t* ifx);
+extern volatile sig_atomic_t picoros_keep_running;
+extern void sys_setup_sigint_handler(void);
 
 // Service callback
 picoros_service_reply_t add2_srv_cb(picoros_srv_server_t* server, uint8_t* request, size_t size);
@@ -68,7 +71,7 @@ int main(int argc, char **argv){
         .mode = MODE,
         .locator = LOCATOR,
     };
-    int ret = picoros_parse_args(argc, argv , &ifx);
+    int ret = sys_parse_args(argc, argv , &ifx);
     if(ret != 0){
         return ret;
     }
@@ -84,8 +87,14 @@ int main(int argc, char **argv){
     printf("Declaring service on %s\n", add2_srv.topic.name);
     picoros_service_declare(&node, &add2_srv);
 
-    while(true){
+    sys_setup_sigint_handler();
+    while(picoros_keep_running){
         z_sleep_s(1);
     }
+
+    printf("Closing interface and cleaning up...\n");
+    picoros_service_drop(&add2_srv);
+    picoros_interface_close();
+
     return 0;
 }

--- a/examples/talker.c
+++ b/examples/talker.c
@@ -65,6 +65,7 @@ void picoros_init(picoros_interface_t* ifx){
 void picoros_stop(void){
     printf("Closing interface and cleaning up...\n");
     picoros_publisher_drop(&pub_log);
+    picoros_node_drop(&node);
     picoros_interface_close();
 }
 
@@ -90,6 +91,7 @@ int main(int argc, char **argv){
             z_sleep_s(1);
         }
         else{
+            printf("Connection lost.\n")
             picoros_stop();
             z_sleep_s(1);
             picoros_init(&ifx);

--- a/examples/talker.c
+++ b/examples/talker.c
@@ -2,15 +2,16 @@
  * @file    talker.c
  * @brief   Example talker node for picoros
  * @date    2025-May-27
- * 
+ *
  * @details This example demonstrates a simple ROS publisher node that
  *          publishes string messages on the "picoros/chatter" topic.
- * 
+ *
  * @copyright Copyright (c) 2025 Ubiquity Robotics
  *******************************************************************************/
 
 #include <stdio.h>
 #include <stdint.h>
+#include <signal.h>
 #include "picoros.h"
 #include "picoserdes.h"
 
@@ -19,7 +20,9 @@
 #define LOCATOR     "tcp/192.168.1.16:7447"
 
 // Common utils
-extern int picoros_parse_args(int argc, char **argv, picoros_interface_t* ifx);
+extern int sys_parse_args(int argc, char **argv, picoros_interface_t* ifx);
+extern volatile sig_atomic_t picoros_keep_running;
+extern void sys_setup_sigint_handler(void);
 
 // Example Publisher
 picoros_publisher_t pub_log = {
@@ -45,19 +48,9 @@ void publish_log(){
     picoros_publish(&pub_log, pub_buf, len);
 }
 
-int main(int argc, char **argv){
-    picoros_interface_t ifx = {
-        .mode = MODE,
-        .locator = LOCATOR,
-    };
-    int ret = picoros_parse_args(argc, argv , &ifx);
-
-    if(ret != 0){
-        return ret;
-    }
-
-    printf("Starting pico-ros interface %s %s\n", ifx.mode, ifx.locator );
-    while (picoros_interface_init(&ifx) == PICOROS_NOT_READY){
+void picoros_init(picoros_interface_t* ifx){
+    printf("Starting pico-ros interface %s %s\n", ifx->mode, ifx->locator );
+    while (picoros_interface_init(ifx) == PICOROS_NOT_READY){
         printf("Waiting RMW init...\n");
         z_sleep_s(1);
     }
@@ -67,10 +60,43 @@ int main(int argc, char **argv){
 
     printf("Declaring publisher on %s\n", pub_log.topic.name);
     picoros_publisher_declare(&node, &pub_log);
+}
 
-    while(true){
+void picoros_stop(void){
+    printf("Closing interface and cleaning up...\n");
+    picoros_publisher_drop(&pub_log);
+    picoros_interface_close();
+}
+
+int main(int argc, char **argv){
+    picoros_interface_t ifx = {
+        .mode = MODE,
+        .locator = LOCATOR,
+    };
+    int ret = sys_parse_args(argc, argv , &ifx);
+    if(ret != 0){
+        return ret;
+    }
+    picoros_init(&ifx);
+
+    sys_setup_sigint_handler();
+    while(picoros_keep_running){
+      #if Z_FEATURE_AUTO_RECONNECT == 1
         publish_log();
         z_sleep_s(1);
+      #else
+        if (picoros_interface_is_up()){
+            publish_log();
+            z_sleep_s(1);
+        }
+        else{
+            picoros_stop();
+            z_sleep_s(1);
+            picoros_init(&ifx);
+        }
+      #endif
     }
+
+    picoros_stop();
     return 0;
 }

--- a/examples/talker.c
+++ b/examples/talker.c
@@ -91,7 +91,7 @@ int main(int argc, char **argv){
             z_sleep_s(1);
         }
         else{
-            printf("Connection lost.\n")
+            printf("Connection lost.\n");
             picoros_stop();
             z_sleep_s(1);
             picoros_init(&ifx);

--- a/examples/talker.cpp
+++ b/examples/talker.cpp
@@ -11,6 +11,7 @@
 
 #include <cstdio>
 #include <cstdint>
+#include <csignal>
 #include "picoros.h"
 #include "picoserdes.h"
 
@@ -19,7 +20,9 @@ constexpr const char* MODE = "client";
 constexpr const char* LOCATOR = "tcp/192.168.1.16:7447";
 
 // Common utils
-extern "C" int picoros_parse_args(int argc, char **argv, picoros_interface_t* ifx);
+extern "C" int sys_parse_args(int argc, char **argv, picoros_interface_t* ifx);
+extern "C" volatile sig_atomic_t picoros_keep_running;
+extern "C" void sys_setup_sigint_handler(void);
 
 // Example Publisher
 picoros_publisher_t pub_log = {
@@ -50,8 +53,7 @@ int main(int argc, char **argv) {
         .mode = const_cast<char*>(MODE),
         .locator = const_cast<char*>(LOCATOR),
     };
-    int ret = picoros_parse_args(argc, argv, &ifx);
-
+    int ret = sys_parse_args(argc, argv, &ifx);
     if (ret != 0) {
         return ret;
     }
@@ -68,9 +70,15 @@ int main(int argc, char **argv) {
     std::printf("Declaring publisher on %s\n", pub_log.topic.name);
     picoros_publisher_declare(&node, &pub_log);
 
-    while (true) {
+    sys_setup_sigint_handler();
+    while (picoros_keep_running) {
         publish_log();
         z_sleep_s(1);
     }
+
+    std::printf("Closing interface and cleaning up...\n");
+    picoros_publisher_drop(&pub_log);
+    picoros_interface_close();
+
     return 0;
 }

--- a/examples/talker.cpp
+++ b/examples/talker.cpp
@@ -78,6 +78,7 @@ int main(int argc, char **argv) {
 
     std::printf("Closing interface and cleaning up...\n");
     picoros_publisher_drop(&pub_log);
+    picoros_node_drop(&node);
     picoros_interface_close();
 
     return 0;

--- a/examples/talker.cpp
+++ b/examples/talker.cpp
@@ -2,10 +2,10 @@
  * @file    talker.cpp
  * @brief   Example cpp talker node for picoros
  * @date    2025-Avg-8
- * 
+ *
  * @details This example demonstrates a simple ROS publisher node that
  *          publishes string messages on the "picoros/chatter" topic.
- * 
+ *
  * @copyright Copyright (c) 2025 Ubiquity Robotics
  *******************************************************************************/
 

--- a/src/picoparams.c
+++ b/src/picoparams.c
@@ -108,9 +108,16 @@ picoros_res_t picoparams_init(picoros_node_t* node, picoparams_interface_t ifx){
     if(picoros_service_declare(node, &pserver.get_types_srv) != PICOROS_OK){ return PICOROS_ERROR; }
 
     return PICOROS_OK;
-
 }
 
+void picoparams_stop(void){
+    picoros_service_drop(&pserver.get_srv);
+    picoros_service_drop(&pserver.list_srv);
+    picoros_service_drop(&pserver.set_srv);
+    picoros_service_drop(&pserver.describe_srv);
+    picoros_service_drop(&pserver.set_atomic_srv);
+    picoros_service_drop(&pserver.get_types_srv);
+}
 
 /* Private functions ---------------------------------------------------------*/
 static size_t serialize_ros_ParameterValue(ucdrBuffer* writer, pp_ParameterValue* val){

--- a/src/picoparams.h
+++ b/src/picoparams.h
@@ -2,9 +2,9 @@
  * @file    picoparams.h
  * @brief   Pico-ROS Parameter Server Implementation
  * @date    2025-Jun-01
- * 
+ *
  * @details This module implements a ROS 2 compatible parameter server for embedded systems.
- * 
+ *
  * @copyright Copyright (c) 2025 Ubiquity Robotics
  *******************************************************************************/
 
@@ -203,13 +203,17 @@ typedef struct {
 
 /**
  * @brief Initialize parameter server
- * @param server Parameter server instance
  * @param node ROS node
  * @param ifx Parameter interface
  * @return PICOROS_OK on success, error code otherwise
  */
-picoros_res_t picoparams_init(picoros_node_t* node, picoparams_interface_t ifx);
+ picoros_res_t picoparams_init(picoros_node_t* node, picoparams_interface_t ifx);
 
+ /**
+  * @brief Stop parameter server and release resources
+  * @return void
+  */
+void picoparams_stop(void);
 
 /* Exported constants --------------------------------------------------------*/
 /* Exported macro ------------------------------------------------------------*/

--- a/src/picoros.c
+++ b/src/picoros.c
@@ -305,6 +305,15 @@ picoros_res_t picoros_single_threaded_loop(picoros_interface_t* ifx){
 }
 #endif
 
+bool picoros_interface_is_up(void) {
+    return zp_read_task_is_running(z_session_loan(&s_wrapper));
+}
+
+void picoros_interface_close(void) {
+    z_close(z_session_loan_mut(&s_wrapper), NULL);
+    z_session_drop(z_session_move(&s_wrapper));
+}
+
 picoros_res_t picoros_node_init(picoros_node_t* node) {
     z_result_t res = Z_OK;
     char keyexpr[KEYEXPR_SIZE];
@@ -321,10 +330,6 @@ picoros_res_t picoros_node_init(picoros_node_t* node) {
         return PICOROS_ERROR;
     }
     return PICOROS_OK;
-}
-
-void zenoh_shutdown() {
-    z_session_drop(z_session_move(&s_wrapper));
 }
 
 picoros_res_t picoros_publisher_declare(picoros_node_t* node, picoros_publisher_t* pub) {
@@ -385,6 +390,10 @@ picoros_res_t picoros_publish(picoros_publisher_t* pub, uint8_t* payload, size_t
     return PICOROS_OK;
 }
 
+picoros_res_t picoros_publisher_drop(picoros_publisher_t* pub) {
+    return (z_undeclare_publisher(z_publisher_move(&pub->zpub)) == Z_OK) ? PICOROS_OK : PICOROS_ERROR;
+}
+
 // Subscribe to a topic
 picoros_res_t picoros_subscriber_declare(picoros_node_t* node, picoros_subscriber_t* sub) {
     char keyexpr[KEYEXPR_SIZE];
@@ -418,6 +427,10 @@ picoros_res_t picoros_subscriber_declare(picoros_node_t* node, picoros_subscribe
         }
     }
     return PICOROS_OK;
+}
+
+picoros_res_t picoros_subscriber_drop(picoros_subscriber_t* sub) {
+    return (z_undeclare_subscriber(z_subscriber_move(&sub->zsub)) == Z_OK) ? PICOROS_OK : PICOROS_ERROR;
 }
 
 picoros_res_t picoros_service_declare(picoros_node_t* node, picoros_srv_server_t* srv) {
@@ -458,6 +471,9 @@ picoros_res_t picoros_service_declare(picoros_node_t* node, picoros_srv_server_t
     return PICOROS_OK;
 }
 
+picoros_res_t picoros_service_drop(picoros_srv_server_t* serv) {
+    return (z_undeclare_queryable(z_queryable_move(&serv->zqable)) == Z_OK) ? PICOROS_OK : PICOROS_ERROR;
+}
 
 picoros_res_t picoros_service_client_init(picoros_srv_client_t * client){
     if (client->_key_buf == NULL){
@@ -535,6 +551,8 @@ bool picoros_service_call_in_progress(picoros_srv_client_t* client){
     return client->_in_progress;
 }
 
-picoros_res_t picoros_unsubscribe(picoros_subscriber_t* sub) {
-    return (z_undeclare_subscriber(z_subscriber_move(&sub->zsub)) == Z_OK) ? PICOROS_OK : PICOROS_ERROR;
+picoros_res_t picoros_service_client_drop(picoros_srv_client_t* client) {
+    z_free(client->_key_buf);
+    client->_key_buf = NULL;
+    return PICOROS_OK;
 }

--- a/src/picoros.c
+++ b/src/picoros.c
@@ -306,7 +306,8 @@ picoros_res_t picoros_single_threaded_loop(picoros_interface_t* ifx){
 #endif
 
 bool picoros_interface_is_up(void) {
-    return zp_read_task_is_running(z_session_loan(&s_wrapper));
+    return ( zp_read_task_is_running(z_session_loan(&s_wrapper))
+    || zp_lease_task_is_running(z_session_loan(&s_wrapper)) );
 }
 
 void picoros_interface_close(void) {

--- a/src/picoros.c
+++ b/src/picoros.c
@@ -272,9 +272,38 @@ picoros_res_t picoros_interface_init(picoros_interface_t* ifx) {
         _PR_LOG("Failed to start read/lease tasks! Error:%d\n", res);
         return PICOROS_ERROR;
     }
+    #if Z_FEATURE_MULTI_THREAD == 0
+        ifx->last_keepalive_time = z_clock_now();
+    #endif
 
     return PICOROS_OK;
 }
+
+#if Z_FEATURE_MULTI_THREAD == 0
+picoros_res_t picoros_single_threaded_loop(picoros_interface_t* ifx){
+    z_result_t res = Z_OK;
+    res = zp_read(z_session_loan(&s_wrapper), ifx->read_opts);
+    if (res != Z_OK){
+        _PR_LOG("Read task error:%d\n", res);
+        return PICOROS_ERROR;
+    }
+    unsigned long elapsed_ms = z_clock_elapsed_ms(&ifx->last_keepalive_time);
+    if (elapsed_ms >= (Z_TRANSPORT_LEASE / Z_TRANSPORT_LEASE_EXPIRE_FACTOR)) {
+        ifx->last_keepalive_time = z_clock_now();
+        res = zp_send_keep_alive(z_session_loan(&s_wrapper), ifx->keep_alive_opts);
+        if (res != Z_OK){
+            _PR_LOG("Keep alive task error:%d\n", res);
+            return PICOROS_ERROR;
+        }
+        res = zp_send_join(z_session_loan(&s_wrapper), ifx->join_options);
+        if (res != Z_OK){
+            _PR_LOG("Join task error:%d\n", res);
+            return PICOROS_ERROR;
+        }
+    }
+    return PICOROS_OK;
+}
+#endif
 
 picoros_res_t picoros_node_init(picoros_node_t* node) {
     z_result_t res = Z_OK;

--- a/src/picoros.c
+++ b/src/picoros.c
@@ -323,12 +323,15 @@ picoros_res_t picoros_node_init(picoros_node_t* node) {
 
     z_view_keyexpr_from_str(&ke, keyexpr);
 
-    z_owned_liveliness_token_t token;
-
-    if ((res = z_liveliness_declare_token(z_session_loan(&s_wrapper), &token, z_view_keyexpr_loan(&ke), NULL)) != Z_OK) {
+    if ((res = z_liveliness_declare_token(z_session_loan(&s_wrapper), &node->lv_token, z_view_keyexpr_loan(&ke), NULL)) != Z_OK) {
         _PR_LOG("Unable to declare node liveliness token! Error:%d\n", res);
         return PICOROS_ERROR;
     }
+    return PICOROS_OK;
+}
+
+picoros_res_t picoros_node_drop(picoros_node_t* node) {
+    z_liveliness_token_drop(z_liveliness_token_move(&node->lv_token));
     return PICOROS_OK;
 }
 
@@ -357,8 +360,7 @@ picoros_res_t picoros_publisher_declare(picoros_node_t* node, picoros_publisher_
         rmw_zenoh_topic_liveliness_keyexpr(node, &pub->topic, keyexpr, "MP");
         z_view_keyexpr_from_str(&ke2, keyexpr);
 
-        z_owned_liveliness_token_t token;
-        if ((res = z_liveliness_declare_token(z_session_loan(&s_wrapper), &token, z_view_keyexpr_loan(&ke2), NULL)) != Z_OK) {
+        if ((res = z_liveliness_declare_token(z_session_loan(&s_wrapper), &pub->lv_token, z_view_keyexpr_loan(&ke2), NULL)) != Z_OK) {
             _PR_LOG("Unable to declare publisher liveliness token! Error:%d\n", res);
             return PICOROS_ERROR;
         }
@@ -391,6 +393,7 @@ picoros_res_t picoros_publish(picoros_publisher_t* pub, uint8_t* payload, size_t
 }
 
 picoros_res_t picoros_publisher_drop(picoros_publisher_t* pub) {
+    z_liveliness_token_drop(z_liveliness_token_move(&pub->lv_token));
     return (z_undeclare_publisher(z_publisher_move(&pub->zpub)) == Z_OK) ? PICOROS_OK : PICOROS_ERROR;
 }
 
@@ -420,8 +423,7 @@ picoros_res_t picoros_subscriber_declare(picoros_node_t* node, picoros_subscribe
     if (sub->topic.type != NULL) {
         rmw_zenoh_topic_liveliness_keyexpr(node, &sub->topic, keyexpr, "MS");
         z_view_keyexpr_from_str(&ke, keyexpr);
-        z_owned_liveliness_token_t token;
-        if ((res = z_liveliness_declare_token(z_session_loan(&s_wrapper), &token, z_view_keyexpr_loan(&ke), NULL)) != Z_OK) {
+        if ((res = z_liveliness_declare_token(z_session_loan(&s_wrapper), &sub->lv_token, z_view_keyexpr_loan(&ke), NULL)) != Z_OK) {
             _PR_LOG("Unable to declare subscriber liveliness token! Error:%d\n", res);
             return PICOROS_ERROR;
         }
@@ -430,6 +432,7 @@ picoros_res_t picoros_subscriber_declare(picoros_node_t* node, picoros_subscribe
 }
 
 picoros_res_t picoros_subscriber_drop(picoros_subscriber_t* sub) {
+    z_liveliness_token_drop(z_liveliness_token_move(&sub->lv_token));
     return (z_undeclare_subscriber(z_subscriber_move(&sub->zsub)) == Z_OK) ? PICOROS_OK : PICOROS_ERROR;
 }
 
@@ -460,10 +463,9 @@ picoros_res_t picoros_service_declare(picoros_node_t* node, picoros_srv_server_t
     }
     if (srv->topic.type != NULL) {
         z_view_keyexpr_t ke2;
-        z_owned_liveliness_token_t token;
         rmw_zenoh_topic_liveliness_keyexpr(node, &srv->topic, keyexpr, "SS");
         z_view_keyexpr_from_str(&ke2, keyexpr);
-        if ((res = z_liveliness_declare_token(z_session_loan(&s_wrapper), &token, z_view_keyexpr_loan(&ke2), NULL)) != Z_OK) {
+        if ((res = z_liveliness_declare_token(z_session_loan(&s_wrapper), &srv->lv_token, z_view_keyexpr_loan(&ke2), NULL)) != Z_OK) {
             _PR_LOG("Unable to declare service liveliness token! Error:%d\n", res);
             return PICOROS_ERROR;
         }
@@ -472,6 +474,7 @@ picoros_res_t picoros_service_declare(picoros_node_t* node, picoros_srv_server_t
 }
 
 picoros_res_t picoros_service_drop(picoros_srv_server_t* serv) {
+    z_liveliness_token_drop(z_liveliness_token_move(&serv->lv_token));
     return (z_undeclare_queryable(z_queryable_move(&serv->zqable)) == Z_OK) ? PICOROS_OK : PICOROS_ERROR;
 }
 

--- a/src/picoros.h
+++ b/src/picoros.h
@@ -227,6 +227,12 @@ typedef struct {
 typedef struct {
     char* mode;                     /**< Connection mode (peer/client) */
     char* locator;                  /**< Network locator string */
+    #if Z_FEATURE_MULTI_THREAD == 0
+        z_clock_t                       last_keepalive_time; /**< Last time of sent keepalive message */
+        zp_read_options_t*              read_opts;           /**< Read options */
+        zp_send_keep_alive_options_t*   keep_alive_opts;     /**< Keep alive options */
+        zp_send_join_options_t*         join_options;        /**< Join options - multicast only */
+    #endif
 } picoros_interface_t;
 
 /** @} */
@@ -249,6 +255,17 @@ typedef enum {
  * @ingroup interface
  */
 picoros_res_t picoros_interface_init(picoros_interface_t* ifx);
+
+#if Z_FEATURE_MULTI_THREAD == 0
+/**
+ * @brief Run single threaded communication tasks.
+ * @param context Pointer to interface configuration.
+ * @return PICOROS_OK on success, error code otherwise
+ * @ingroup interface
+ */
+picoros_res_t picoros_single_threaded_loop(picoros_interface_t* ifx);
+
+#endif
 
 /**
  * @brief Shutdown the network interface

--- a/src/picoros.h
+++ b/src/picoros.h
@@ -268,10 +268,16 @@ picoros_res_t picoros_single_threaded_loop(picoros_interface_t* ifx);
 #endif
 
 /**
- * @brief Shutdown the network interface
+ * @brief Check if network interface is running
  * @ingroup interface
  */
-void picoros_interface_shutdown(void);
+bool picoros_interface_is_up(void);
+
+/**
+ * @brief Close the network interface
+ * @ingroup interface
+ */
+void picoros_interface_close(void);
 
 /**
  * @brief Initialize a ROS node
@@ -301,6 +307,14 @@ picoros_res_t picoros_publisher_declare(picoros_node_t* node, picoros_publisher_
 picoros_res_t picoros_publish(picoros_publisher_t *pub, uint8_t *payload, size_t len);
 
 /**
+ * @brief Undeclare a publisher and release resources
+ * @param pub Pointer to publisher instance
+ * @return PICOROS_OK on success, error code otherwise
+ * @ingroup publisher
+ */
+picoros_res_t picoros_publisher_drop(picoros_publisher_t *pub);
+
+/**
  * @brief Declare a subscriber for a node
  * @param node Pointer to node instance
  * @param sub Pointer to subscriber configuration
@@ -310,12 +324,12 @@ picoros_res_t picoros_publish(picoros_publisher_t *pub, uint8_t *payload, size_t
 picoros_res_t picoros_subscriber_declare(picoros_node_t* node, picoros_subscriber_t *sub);
 
 /**
- * @brief Unsubscribe from a topic
+ * @brief Unsubscribe from a topic and release resources
  * @param sub Pointer to subscriber instance
  * @return PICOROS_OK on success, error code otherwise
  * @ingroup subscriber
  */
-picoros_res_t picoros_unsubscribe(picoros_subscriber_t *sub);
+picoros_res_t picoros_subscriber_drop(picoros_subscriber_t *sub);
 
 /**
  * @brief Declare a service server for a node
@@ -325,6 +339,14 @@ picoros_res_t picoros_unsubscribe(picoros_subscriber_t *sub);
  * @ingroup service_server
  */
 picoros_res_t picoros_service_declare(picoros_node_t* node, picoros_srv_server_t* srv);
+
+/**
+ * @brief Undeclare a service server and release resources
+ * @param srv Pointer to service server instance
+ * @return PICOROS_OK on success, error code otherwise
+ * @ingroup service_server
+ */
+picoros_res_t picoros_service_drop(picoros_srv_server_t* srv);
 
 
 /**
@@ -353,6 +375,14 @@ picoros_res_t picoros_service_call(picoros_srv_client_t* client, uint8_t* payloa
  * @ingroup service_client
  */
 bool picoros_service_call_in_progress(picoros_srv_client_t* client);
+
+/**
+ * @brief Release resources allocated by service client.
+ * @param client Pointer to client instance.
+ * @return PICOROS_OK on success, error code otherwise
+ * @ingroup service_client
+ */
+picoros_res_t picoros_service_client_drop(picoros_srv_client_t* client);
 
 #ifdef __cplusplus
 }

--- a/src/picoros.h
+++ b/src/picoros.h
@@ -109,6 +109,7 @@ typedef struct picoros_srv_server_s{
     rmw_attachment_t         attachment;     /**< RMW attachment data */
     void*                    user_data;      /**< User data, not used by picoros */
     picoros_srv_server_cb_t  user_callback;  /**< User callback for service handling */
+    z_owned_liveliness_token_t lv_token;     /**< Liveliness token for service discovery */
 } picoros_srv_server_t;
 
 /** @} */
@@ -168,6 +169,7 @@ typedef struct {
     rmw_attachment_t   attachment;  /**< RMW attachment data */
     rmw_topic_t        topic;       /**< Topic information */
     z_publisher_options_t opts;     /**< Topic options, if NULL default options are used */
+    z_owned_liveliness_token_t lv_token; /**< Liveliness token for publisher discovery */
 } picoros_publisher_t;
 
 /** @} */
@@ -194,6 +196,7 @@ typedef struct {
     z_owned_subscriber_t zsub;         /**< Zenoh subscriber instance */
     rmw_topic_t         topic;         /**< Topic information */
     picoros_sub_cb_t    user_callback; /**< User callback for data handling */
+    z_owned_liveliness_token_t lv_token; /**< Liveliness token for subscriber discovery */
 } picoros_subscriber_t;
 
 /** @} */
@@ -211,6 +214,7 @@ typedef struct {
     const char* name;                  /**< Node name */
     uint32_t    domain_id;             /**< ROS domain ID */
     uint8_t     guid[RMW_GID_SIZE];    /**< Node GUID */
+    z_owned_liveliness_token_t lv_token; /**< Liveliness token for node discovery */
 } picoros_node_t;
 
 /** @} */
@@ -286,6 +290,14 @@ void picoros_interface_close(void);
  * @ingroup node
  */
 picoros_res_t picoros_node_init(picoros_node_t* node);
+
+/**
+ * @brief Release resources allocated by node
+ * @param node Pointer to node instance
+ * @return PICOROS_OK on success, error code otherwise
+ * @ingroup node
+ */
+picoros_res_t picoros_node_drop(picoros_node_t* node);
 
 /**
  * @brief Declare a publisher for a node


### PR DESCRIPTION
This PR adds capability for application code to properly cleanup resources in Z_FEATURE_AUTO_RECONNECT=0 case.

- Add functions to allow manual cleanup of allocated memory.
- Update zenoh-pico to custom version (see  https://github.com/eclipse-zenoh/zenoh-pico/pull/1126 for details).
- Update examples to show usage of new cleanup functions
